### PR TITLE
allows the chatgpt backstory output to be displayed on a page

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -172,4 +172,5 @@ img {
 .greeting {
   font-size: 2rem;
   margin: 1rem;
+  margin-bottom: 50px;
 }

--- a/public/js/chatgptscriptgetbackstory.js
+++ b/public/js/chatgptscriptgetbackstory.js
@@ -1,3 +1,5 @@
+const parentElement = document.querySelector('#testappend');
+
 const getBackstory = async () => {
   const options = {
     method: 'POST',
@@ -9,13 +11,23 @@ const getBackstory = async () => {
       'Content-Type': 'application/json',
     },
   };
+
   try {
-    await fetch('http://localhost:3001/api/chatgpt/getbackstory', options);
+    const response = await fetch(
+      'http://localhost:3001/api/chatgpt/getbackstory',
+      options,
+    );
     const data = await response.json();
-    console.log(data);
+    // console.log('test log in the try part');
+    // console.log(data);
+    console.log(data.choices[0].text);
+    const pElement = document.createElement('p');
+    pElement.textContent = data.choices[0].text;
+    parentElement.append(pElement);
   } catch (error) {
     console.error();
   }
 };
 
 getBackstory();
+console.log('the chatgpt backstory script is connected');

--- a/public/js/chatgptscriptgetname.js
+++ b/public/js/chatgptscriptgetname.js
@@ -1,8 +1,10 @@
+const inputElement = document.querySelector('#input');
+
 const getName = async () => {
   const options = {
     method: 'POST',
     body: JSON.stringify({
-      prompt: 'Generate a cool fantasy character name from the 1800s',
+      prompt: `Generate a cool fantasy character name from the 1800s ${inputElement.value}`,
     }),
     headers: {
       'Content-Type': 'application/json',
@@ -12,9 +14,21 @@ const getName = async () => {
     await fetch('http://localhost:3001/api/chatgpt/namegen', options);
     const data = await response.json();
     console.log(data);
+    console.log(data.choices[0].text);
+    element.textContent = data.choices[0].text;
+    if (data.choices[0].message.text && inputElement.value) {
+      const pElement = document.createElement('p');
+      pElement.textContent = inputElement.value;
+      pElement.addEventListener('click', () =>
+        changeInput(pElement.textContent),
+      );
+      historyElement.append(pElement);
+    }
   } catch (error) {
     console.error();
   }
 };
 
 getName();
+
+//something that shows things are loading

--- a/views/homepage.handlebars
+++ b/views/homepage.handlebars
@@ -15,9 +15,15 @@ A CARD leading to character page }}
   <body>
     {{#if loggedIn}}
       <button>Previous Character</button>
-      <button>Build New Character</button>
+      <a href='./partials/char-form.handlebars'><button>Build New Character</button></a>
+      <p id='testappend'>P text for LB testing with chatgpt</p>
+      {{! <div class='input-container'>
+        <input />
+        <div id='submit'>➢</div>
+      </div> }}
     {{/if}}
+
     <script src='/js/chatgptscriptgetbackstory.js'></script>
-    <script src='/js/chatgptscriptgetname.js'></script>
+    {{! <script src='/js/chatgptscriptgetname.js'></script> }}
   </body>
 </html>


### PR DESCRIPTION
## Describe your changes
this change is to get chatgpt output actually displaying on our webpage. The front-end js for the backstory now fetches from our back-end route and renders output on the homepage. (Once we have a character gen page we can put this output there instead of on the homepage). 

## Checklist before requesting a review

- [x ] I have performed a self-review of my code
- [x] I have confirmed I am working on a separate branch from Main.
- [x ] If it is a core feature, I have tested thoroughly.
