### PR TITLE
reenables the chatgpt script on the output page as we had commented i…

### DIFF
--- a/views/partials/output.handlebars
+++ b/views/partials/output.handlebars
@@ -10,7 +10,7 @@
   <p>No character found.</p>
 {{/if}}
 
-{{! <script src='/js/chatgptscript.js'></script>
-<script src='/js/saveoutput.js'></script> }}
+<script src='/js/chatgptscript.js'></script>
+<script src='/js/saveoutput.js'></script>
 <script src='/js/retrieve-image.js'></script>
 {{! <script src='/js/imgoutputtest.js'></script> }}


### PR DESCRIPTION
…t out for testing

## Describe your changes
On the output handbars page, the chatgpt script and save script were commented out bc of our work on the image api alone yesterday. This PR makes those two scripts active again on the page. 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have confirmed I am working on a separate branch from Main.
- [x] If it is a core feature, I have tested thoroughly.
